### PR TITLE
register_uninstall_hook fire only activate plugin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -64,8 +64,10 @@ add_action( 'plugins_loaded', function () {
  *
  * @since 0.0.1 (Alpha)
  */
+register_activation_hook( __FILE__, function(){
+	register_uninstall_hook( __FILE__, array( VASOCIALBUZZ\Modules\VASOCIALBUZZ_Installer::class , 'uninstall' ) );
+} );
+
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG === true ) {
-	register_deactivation_hook( __FILE__, array( '\VASOCIALBUZZ\Modules\VASOCIALBUZZ_Installer', 'uninstall' ) );
-} else {
-	register_uninstall_hook( __FILE__, array( '\VASOCIALBUZZ\Modules\VASOCIALBUZZ_Installer', 'uninstall' ) );
+	register_deactivation_hook( __FILE__, array( VASOCIALBUZZ\Modules\VASOCIALBUZZ_Installer::class , 'uninstall' ) );
 }


### PR DESCRIPTION
register_uninstall_hook fire update_option. So, fire only activate plugin.

see: 
* https://developer.wordpress.org/reference/functions/register_uninstall_hook/#user-contributed-notes
* https://github.com/torounit/custom-post-type-permalinks/issues/56


